### PR TITLE
Fixed Nav Link

### DIFF
--- a/docs/manual/.vitepress/config.mts
+++ b/docs/manual/.vitepress/config.mts
@@ -63,7 +63,7 @@ export default defineConfig({
       copyright: '©2025 Opsloom'
     },
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/opsloom/' }
+      { icon: 'github', link: 'https://github.com/leaninnovationlabs/opsloom' }
     ]
   }
 })


### PR DESCRIPTION
Updated navbar link on the docs page to point to the correct github instance