### PR TITLE
Improve Makefile and test setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.PHONY: dev backend frontend start-db stop-db migrate test
+
+start-db:
+	sh db/start_postgres.sh
+
+stop-db:
+	sh db/stop_postgres.sh
+
+migrate: start-db
+	PYTHONPATH=$(PWD) uv run alembic upgrade head
+
+backend: migrate
+	PYTHONPATH=$(PWD) uv run uvicorn server:app --reload --port 8080
+
+frontend:
+	cd frontend && npm install && npm run dev
+
+dev: migrate
+	PYTHONPATH=$(PWD) uv run uvicorn server:app --reload --port 8080 &
+	cd frontend && npm install && npm run dev
+
+test: start-db
+	PYTHONPATH=$(PWD) uv run alembic upgrade head
+	PYTHONPATH=$(PWD) uv run pytest -q
+	sh db/stop_postgres.sh

--- a/db/start_postgres.sh
+++ b/db/start_postgres.sh
@@ -28,5 +28,11 @@ else
     -e POSTGRES_USER="$DB_USER" \
     -e POSTGRES_PASSWORD="$DB_PASSWORD" \
     -p 5432:5432 \
-    pgvector/pgvector:pg16
+pgvector/pgvector:pg16
 fi
+
+echo "Waiting for Postgres to be ready..."
+until sudo docker exec "$CONTAINER_NAME" pg_isready -U "$DB_USER" >/dev/null 2>&1; do
+  sleep 1
+done
+echo "Postgres is ready."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,7 @@ dependencies = [
     "openai>=1.59.8",
     "pgvector>=0.3.6",
 ]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+asyncio_mode = "strict"

--- a/tests/test_account_models.py
+++ b/tests/test_account_models.py
@@ -1,0 +1,21 @@
+import uuid
+import pytest
+from backend.api.account.account_schema import AccountORM
+from backend.api.account.models import Account
+
+
+def test_account_model_validation():
+    orm = AccountORM(
+        account_id=uuid.uuid4(),
+        short_code="test",
+        name="Test Account",
+        email="test@example.com",
+        protection="none",
+        account_metadata={"foo": "bar"},
+        root=False,
+    )
+    model = Account.model_validate(orm)
+    assert model.account_id == orm.account_id
+    assert model.short_code == orm.short_code
+    assert model.email == orm.email
+    assert model.metadata == orm.account_metadata

--- a/tests/test_account_repository.py
+++ b/tests/test_account_repository.py
@@ -1,0 +1,37 @@
+import os
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.api.account.repository import AccountRepository
+from backend.api.account.models import AccountCreate, AccountUpdate
+from backend.api.account.account_schema import AccountORM
+
+DATABASE_URL = os.getenv("POSTGRES_CONNECTION_STRING", "postgresql+asyncpg://myuser:mypassword@localhost:5432/ragdb")
+
+engine = create_async_engine(DATABASE_URL, future=True)
+AsyncSessionLocal = sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)
+
+@pytest.fixture
+async def session():
+    async with AsyncSessionLocal() as session:
+        yield session
+
+@pytest.mark.asyncio
+async def test_create_and_get_account(session: AsyncSession):
+    repo = AccountRepository(session)
+    acct = AccountCreate(email="repo@example.com", short_code="repo", name="Repo")
+    created = await repo.create_account(acct)
+    fetched = await repo.get_account_by_id(created.account_id)
+    assert fetched.email == "repo@example.com"
+    await repo.delete_account(created.account_id)
+
+@pytest.mark.asyncio
+async def test_update_account(session: AsyncSession):
+    repo = AccountRepository(session)
+    acct = AccountCreate(email="update@example.com", short_code="upd", name="Upd")
+    created = await repo.create_account(acct)
+    update = AccountUpdate(account_id=created.account_id, name="Updated")
+    updated = await repo.update_account(update)
+    assert updated.name == "Updated"
+    await repo.delete_account(created.account_id)

--- a/tests/test_account_service.py
+++ b/tests/test_account_service.py
@@ -1,0 +1,34 @@
+import os
+import uuid
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.api.account.services import AccountService
+from backend.api.account.repository import AccountRepository
+from backend.api.account.models import AccountCreate
+from backend.lib.exceptions import AccountNotFoundError
+
+DATABASE_URL = os.getenv("POSTGRES_CONNECTION_STRING", "postgresql+asyncpg://myuser:mypassword@localhost:5432/ragdb")
+engine = create_async_engine(DATABASE_URL, future=True)
+AsyncSessionLocal = sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)
+
+@pytest.fixture
+async def service():
+    async with AsyncSessionLocal() as session:
+        repo = AccountRepository(session)
+        service = AccountService(repo)
+        yield service
+
+@pytest.mark.asyncio
+async def test_service_create_and_get(service: AccountService):
+    acct = AccountCreate(email="svc@example.com", short_code="svc", name="Svc")
+    created = await service.create_account(acct)
+    fetched = await service.get_account(created.account_id)
+    assert fetched.email == acct.email
+    await service.repository.delete_account(created.account_id)
+
+@pytest.mark.asyncio
+async def test_service_get_missing(service: AccountService):
+    with pytest.raises(AccountNotFoundError):
+        await service.get_account(uuid.uuid4())

--- a/tests/test_auth_utils.py
+++ b/tests/test_auth_utils.py
@@ -1,0 +1,20 @@
+import pytest
+from backend.util.auth_utils import PasswordService
+
+
+def test_hash_and_verify_password():
+    service = PasswordService()
+    plain = "s3cret"
+    hashed = service.hash_password(plain)
+    assert hashed.startswith("$argon2")
+    assert service.verify_password(hashed, plain)
+    assert not service.verify_password(hashed, "wrong")
+
+
+def test_validate_password_requirements():
+    service = PasswordService()
+    ok, msg = service.validate_password_requirements("abcd")
+    assert ok
+    ok, msg = service.validate_password_requirements("abc")
+    assert not ok
+    assert "at least" in msg

--- a/tests/test_token_blacklist.py
+++ b/tests/test_token_blacklist.py
@@ -1,0 +1,11 @@
+import time
+from backend.util.token_blacklist import InMemoryTokenBlacklist
+
+
+def test_blacklist_expires():
+    bl = InMemoryTokenBlacklist()
+    token = "abc"
+    bl.add_to_blacklist(token, time.time() + 1)
+    assert bl.is_blacklisted(token)
+    time.sleep(1.1)
+    assert not bl.is_blacklisted(token)


### PR DESCRIPTION
## Summary
- set PYTHONPATH when running backend and tests
- wait for postgres container to be ready
- configure pytest pythonpath in `pyproject.toml`
- add password service and blacklist tests

## Testing
- `make test` *(fails: docker not found)*
- `PYTHONPATH=$(pwd) uv run pytest -q` *(fails: No route to host)*