### PR TITLE
Add Makefile and tests fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: dev backend frontend start-db stop-db migrate test
+
+	PYTHONPATH := $(CURDIR)
+
+start-db:
+	sh db/start_postgres.sh
+
+stop-db:
+	sh db/stop_postgres.sh
+
+migrate: start-db
+	PYTHONPATH=$(PYTHONPATH) uv run alembic upgrade head
+
+backend: migrate
+	PYTHONPATH=$(PYTHONPATH) uv run uvicorn server:app --reload --port 8080
+
+frontend:
+	cd frontend && npm install && npm run dev
+
+dev: migrate
+	PYTHONPATH=$(PYTHONPATH) uv run uvicorn server:app --reload --port 8080 &
+	cd frontend && npm install && npm run dev
+
+test: start-db
+	PYTHONPATH=$(PYTHONPATH) uv run alembic upgrade head
+	PYTHONPATH=$(PYTHONPATH) uv run pytest -q
+	sh db/stop_postgres.sh

--- a/db/start_postgres.sh
+++ b/db/start_postgres.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Variables
 CONTAINER_NAME="rag-postgres"
@@ -30,3 +31,9 @@ else
     -p 5432:5432 \
     pgvector/pgvector:pg16
 fi
+
+echo "Waiting for Postgres to be ready..."
+until sudo docker exec "$CONTAINER_NAME" pg_isready -U "$DB_USER" >/dev/null 2>&1; do
+  sleep 1
+done
+echo "Postgres is ready."

--- a/tests/test_account_models.py
+++ b/tests/test_account_models.py
@@ -1,0 +1,25 @@
+import uuid
+import datetime as dt
+
+import pytest
+from backend.api.account.account_schema import AccountORM
+from backend.api.account.models import Account
+
+
+def test_account_model_validation():
+    orm = AccountORM(
+        account_id=uuid.uuid4(),
+        short_code="test",
+        name="Test Account",
+        email="test@example.com",
+        protection="none",
+        account_metadata={"foo": "bar"},
+        root=False,
+        created_at=dt.datetime.utcnow(),
+        updated_at=dt.datetime.utcnow(),
+    )
+    model = Account.model_validate(orm)
+    assert model.account_id == orm.account_id
+    assert model.short_code == orm.short_code
+    assert model.email == orm.email
+    assert model.metadata == orm.account_metadata

--- a/tests/test_account_repository.py
+++ b/tests/test_account_repository.py
@@ -1,0 +1,38 @@
+import os
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.api.account.repository import AccountRepository
+from backend.api.account.models import AccountCreate, AccountUpdate
+
+DATABASE_URL = os.getenv("POSTGRES_CONNECTION_STRING", "postgresql+asyncpg://myuser:mypassword@localhost:5432/ragdb")
+
+engine = create_async_engine(DATABASE_URL, future=True)
+AsyncSessionLocal = sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)
+
+import pytest_asyncio
+
+@pytest_asyncio.fixture
+async def session():
+    async with AsyncSessionLocal() as session:
+        yield session
+
+@pytest.mark.asyncio
+async def test_create_and_get_account(session: AsyncSession):
+    repo = AccountRepository(session)
+    acct = AccountCreate(email="repo@example.com", short_code="repo", name="Repo")
+    created = await repo.create_account(acct)
+    fetched = await repo.get_account_by_id(created.account_id)
+    assert fetched.email == "repo@example.com"
+    await repo.delete_account(created.account_id)
+
+@pytest.mark.asyncio
+async def test_update_account(session: AsyncSession):
+    repo = AccountRepository(session)
+    acct = AccountCreate(email="update@example.com", short_code="upd", name="Upd")
+    created = await repo.create_account(acct)
+    update = AccountUpdate(account_id=created.account_id, name="Updated")
+    updated = await repo.update_account(update)
+    assert updated.name == "Updated"
+    await repo.delete_account(created.account_id)

--- a/tests/test_account_service.py
+++ b/tests/test_account_service.py
@@ -1,0 +1,35 @@
+import os
+import uuid
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.api.account.services import AccountService
+from backend.api.account.repository import AccountRepository
+from backend.api.account.models import AccountCreate
+from backend.lib.exceptions import AccountNotFoundError
+
+DATABASE_URL = os.getenv("POSTGRES_CONNECTION_STRING", "postgresql+asyncpg://myuser:mypassword@localhost:5432/ragdb")
+engine = create_async_engine(DATABASE_URL, future=True)
+AsyncSessionLocal = sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)
+
+@pytest_asyncio.fixture
+async def service():
+    async with AsyncSessionLocal() as session:
+        repo = AccountRepository(session)
+        service = AccountService(repo)
+        yield service
+
+@pytest.mark.asyncio
+async def test_service_create_and_get(service: AccountService):
+    acct = AccountCreate(email="svc@example.com", short_code="svc", name="Svc")
+    created = await service.create_account(acct)
+    fetched = await service.get_account(created.account_id)
+    assert fetched.email == acct.email
+    await service.repository.delete_account(created.account_id)
+
+@pytest.mark.asyncio
+async def test_service_get_missing(service: AccountService):
+    with pytest.raises(AccountNotFoundError):
+        await service.get_account(uuid.uuid4())

--- a/tests/test_auth_utils.py
+++ b/tests/test_auth_utils.py
@@ -1,0 +1,18 @@
+import pytest
+from backend.util.auth_utils import PasswordService
+
+
+def test_password_roundtrip():
+    service = PasswordService()
+    hashed = service.hash_password("secret")
+    assert service.verify_password(hashed, "secret")
+    assert not service.verify_password(hashed, "wrong")
+
+
+def test_password_requirements():
+    service = PasswordService()
+    valid, msg = service.validate_password_requirements("abc")
+    assert not valid
+    assert "at least" in msg
+    valid, msg = service.validate_password_requirements("goodpass")
+    assert valid

--- a/tests/test_token_blacklist.py
+++ b/tests/test_token_blacklist.py
@@ -1,0 +1,18 @@
+import time
+from backend.util.token_blacklist import (
+    add_token_to_blacklist,
+    check_token_blacklist,
+    token_blacklist,
+)
+
+
+def test_token_blacklist_expiry(monkeypatch):
+    token_blacklist._blacklist.clear()
+    token_id = "token123"
+    now = time.time()
+    add_token_to_blacklist(token_id, expires_at=None)
+    assert check_token_blacklist(token_id)
+
+    future = now + 3601
+    monkeypatch.setattr(time, "time", lambda: future)
+    assert not check_token_blacklist(token_id)


### PR DESCRIPTION
## Summary
- include PYTHONPATH in Makefile commands and ensure tabs
- wait for postgres readiness in start_postgres.sh
- fix async pytest fixtures and account model test
- add unit tests for password service and token blacklist expiration

## Testing
- `make test` *(fails: docker not found)*
- `PYTHONPATH=$(pwd) uv run pytest -q` *(fails to download python-build-standalone)*