### PR TITLE
Add typed chat blocks

### DIFF
--- a/backend/api/chat/models.py
+++ b/backend/api/chat/models.py
@@ -4,10 +4,20 @@ from uuid import UUID, uuid4
 from typing_extensions import NotRequired, TypedDict
 from pydantic_ai.messages import ModelMessage
 
+
+class MessageBlock(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    type: str
+    text: Optional[str] = None
+    content: Optional[str] = None
+    data: Optional[Any] = None
+    config: Optional[Dict[str, Any]] = None
+
 class Message(BaseModel):
     role: str = "user"
     content: str
-    blocks: List[Dict[str, Any]] = Field(default_factory=list)
+    blocks: List[MessageBlock] = Field(default_factory=list)
     message_id: UUID = Field(default_factory=uuid4)
 
 class AgentMessages(BaseModel):
@@ -45,7 +55,7 @@ class AIResponse(BaseModel):
     sources: List[Source] = Field(default_factory=list)
     relevance_score: float = 0.0
     message_id: UUID = Field(default_factory=uuid4)
-    blocks: List[Dict[str, Any]] = Field(default_factory=list)  # Add this line
+    blocks: List[MessageBlock] = Field(default_factory=list)
 
 class MessageList(BaseModel):
     messages: List[Message]

--- a/backend/api/chat/repository.py
+++ b/backend/api/chat/repository.py
@@ -4,7 +4,13 @@ import json
 from sqlalchemy import select, update, desc
 from sqlalchemy.exc import SQLAlchemyError
 from backend.api.chat.chat_schema import MessageORM, AgentMessageORM
-from backend.api.chat.models import MessagePair, MessageList, Message, AgentMessages
+from backend.api.chat.models import (
+    MessagePair,
+    MessageList,
+    Message,
+    AgentMessages,
+    MessageBlock,
+)
 from backend.util.logging import SetupLogging
 from sqlalchemy.sql import func
 from pydantic_ai.messages import ModelMessagesTypeAdapter
@@ -29,9 +35,9 @@ class ChatRepository:
                 session_id=message_pair.session_id,
                 user_id=message_pair.user_id,
                 account_id=message_pair.account_id,
-                user_message=message_pair.user_message.blocks, 
-                ai_message=message_pair.ai_message.blocks,
-                feedback=message_pair.feedback
+                user_message=[b.model_dump() for b in message_pair.user_message.blocks],
+                ai_message=[b.model_dump() for b in message_pair.ai_message.blocks],
+                feedback=message_pair.feedback,
             )
             self.session.add(message_orm)
             await self.session.commit()
@@ -54,21 +60,21 @@ class ChatRepository:
 
             messages = []
             for row in rows:
-                # Build user message
+                user_blocks = [MessageBlock(**b) for b in (row.user_message or [])]
                 user_msg = Message(
                     role="user",
                     content="",
-                    blocks=row.user_message or [],
-                    message_id=row.id
+                    blocks=user_blocks,
+                    message_id=row.id,
                 )
                 messages.append(user_msg)
 
-                # Build AI message
+                ai_blocks = [MessageBlock(**b) for b in (row.ai_message or [])]
                 ai_msg = Message(
                     role="ai",
                     content="",
-                    blocks=row.ai_message or [],
-                    message_id=row.id
+                    blocks=ai_blocks,
+                    message_id=row.id,
                 )
                 messages.append(ai_msg)
 

--- a/backend/api/chat/services.py
+++ b/backend/api/chat/services.py
@@ -10,7 +10,8 @@ from backend.api.chat.models import (
     Message,
     MessagePair,
     ChatRequest,
-    AIResponse
+    AIResponse,
+    MessageBlock,
 )
 from backend.api.chat.repository import ChatRepository, AgentMessagesRepository
 from backend.api.chat.ai_response_service import AIResponseService
@@ -97,7 +98,7 @@ class ChatService:
             title_sent = False
 
         # We'll store an interim 'block_content'
-        block_content = {}
+        block_content: MessageBlock | None = None
 
         async def response_stream():
             nonlocal full_resp, title_sent, block_content, title_future
@@ -114,52 +115,46 @@ class ChatService:
 
                 # Construct a 'block_content' for JSON. Customize to your UI needs:
                 if chunk_type == "text":
-                    block_content = {
-                        "type": "text",
-                        "text": full_resp.content
-                    }
+                    block_content = MessageBlock(type="text", text=full_resp.content)
                 elif chunk_type == "table":
-                    block_content = {
-                        "type": "table",
-                        "data": content_str,
-                        "config": {
+                    block_content = MessageBlock(
+                        type="table",
+                        data=content_str,
+                        config={
                             "title": response_md.get("title", ""),
                             "description": response_md.get("description", ""),
-                        }
-                    }
+                        },
+                    )
                 elif chunk_type == "dialog":
-                    block_content = {
-                        "type": "dialog",
-                        "content": content_str,
-                        "config": {
+                    block_content = MessageBlock(
+                        type="dialog",
+                        content=content_str,
+                        config={
                             "title": response_md.get("title", ""),
                             "description": response_md.get("description", ""),
-                            "actions": response_md.get("actions", [])
-                        }
-                    }
+                            "actions": response_md.get("actions", []),
+                        },
+                    )
                 elif chunk_type == "barchart":
-                    block_content = {
-                        "type": "barchart",
-                        "data": content_str,
-                        "config": {
+                    block_content = MessageBlock(
+                        type="barchart",
+                        data=content_str,
+                        config={
                             "title": response_md.get("title", ""),
                             "description": response_md.get("description", ""),
                             "xAxis": response_md.get("xAxis", ""),
                             "yAxis": response_md.get("yAxis", ""),
                             "explanation": response_md.get("explanation", ""),
-                        }
-                    }
+                        },
+                    )
                 else:
-                    block_content = {
-                        "type": chunk_type,
-                        "content": content_str
-                    }
+                    block_content = MessageBlock(type=chunk_type, content=content_str)
 
                 # Build partial chunk_data to yield
                 chunk_data = {
                     "message_id": str(full_resp.message_id),
                     "assistant_id": str(assistant_id_uuid),
-                    "blocks": [block_content],
+                    "blocks": [block_content.model_dump()],
                 }
 
                 # If we are generating a new title asynchronously, attach it once it's ready
@@ -178,9 +173,7 @@ class ChatService:
             full_resp.blocks = [block_content] if block_content else []
 
             # 3) Store the user's question as a single text block
-            request.message.blocks = [
-                {"type": "text", "text": request.message.content}
-            ]
+            request.message.blocks = [MessageBlock(type="text", text=request.message.content)]
 
             # 4) If we never attached the title during the loop, do it now
             if title_future and not title_sent:


### PR DESCRIPTION
## Summary
- introduce `MessageBlock` Pydantic model
- use `MessageBlock` everywhere in the chat service and repository

## Testing
- `uv run pytest -q` *(failed: No route to host)*
- `python3 -m py_compile backend/api/chat/models.py backend/api/chat/repository.py backend/api/chat/services.py`