### PR TITLE
Add repo/service tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ Run the docs server using the following command
 npm i
 npm run docs:dev
 ```
+
+## Running the tests
+
+Use the Makefile to start a Postgres container, apply migrations and run
+the unit tests:
+
+```bash
+make test
+```
+
+You can also run the tests directly using `pytest` through uv:
+
+```bash
+uv run pytest -q
+```
 -------------------
 
 # Database Migrations Scripts

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv("POSTGRES_CONNECTION_STRING", "postgresql+asyncpg://myuser:mypassword@localhost:5432/ragdb")
+engine = create_async_engine(DATABASE_URL, future=True)
+AsyncSessionLocal = sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)
+
+@pytest_asyncio.fixture
+async def session():
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/tests/test_account_models.py
+++ b/tests/test_account_models.py
@@ -1,4 +1,5 @@
 import uuid
+import datetime as dt
 import pytest
 from backend.api.account.account_schema import AccountORM
 from backend.api.account.models import Account
@@ -13,6 +14,7 @@ def test_account_model_validation():
         protection="none",
         account_metadata={"foo": "bar"},
         root=False,
+        created_at=dt.datetime.now(),
     )
     model = Account.model_validate(orm)
     assert model.account_id == orm.account_id

--- a/tests/test_account_repository.py
+++ b/tests/test_account_repository.py
@@ -1,21 +1,10 @@
-import os
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.api.account.repository import AccountRepository
 from backend.api.account.models import AccountCreate, AccountUpdate
 from backend.api.account.account_schema import AccountORM
 
-DATABASE_URL = os.getenv("POSTGRES_CONNECTION_STRING", "postgresql+asyncpg://myuser:mypassword@localhost:5432/ragdb")
-
-engine = create_async_engine(DATABASE_URL, future=True)
-AsyncSessionLocal = sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)
-
-@pytest.fixture
-async def session():
-    async with AsyncSessionLocal() as session:
-        yield session
 
 @pytest.mark.asyncio
 async def test_create_and_get_account(session: AsyncSession):

--- a/tests/test_account_service.py
+++ b/tests/test_account_service.py
@@ -1,24 +1,18 @@
-import os
 import uuid
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.api.account.services import AccountService
 from backend.api.account.repository import AccountRepository
 from backend.api.account.models import AccountCreate
 from backend.lib.exceptions import AccountNotFoundError
 
-DATABASE_URL = os.getenv("POSTGRES_CONNECTION_STRING", "postgresql+asyncpg://myuser:mypassword@localhost:5432/ragdb")
-engine = create_async_engine(DATABASE_URL, future=True)
-AsyncSessionLocal = sessionmaker(bind=engine, expire_on_commit=False, class_=AsyncSession)
-
-@pytest.fixture
-async def service():
-    async with AsyncSessionLocal() as session:
-        repo = AccountRepository(session)
-        service = AccountService(repo)
-        yield service
+@pytest_asyncio.fixture
+async def service(session: AsyncSession):
+    repo = AccountRepository(session)
+    svc = AccountService(repo)
+    yield svc
 
 @pytest.mark.asyncio
 async def test_service_create_and_get(service: AccountService):

--- a/tests/test_assistant_models.py
+++ b/tests/test_assistant_models.py
@@ -1,0 +1,35 @@
+import uuid
+from backend.api.assistant.assistant_schema import AssistantORM
+from backend.api.assistant.models import Assistant, AssistantConfig, Metadata
+
+
+def test_assistant_model_validation():
+    # arrange
+    orm = AssistantORM(
+        id=uuid.uuid4(),
+        account_short_code="m",
+        kbase_id=None,
+        name="model",
+        config={"provider": "openai", "type": "rag", "model": "gpt-4o"},
+        system_prompts={"system": "hi"},
+        assistant_metadata={"title": "t", "description": "d", "icon": "i"},
+        active=True,
+    )
+
+    # act
+    model = Assistant.model_validate(
+        {
+            "id": orm.id,
+            "account_short_code": orm.account_short_code,
+            "kbase_id": orm.kbase_id,
+            "name": orm.name,
+            "config": orm.config,
+            "system_prompts": orm.system_prompts,
+            "metadata": orm.assistant_metadata,
+        }
+    )
+
+    # assert
+    assert model.id == orm.id
+    assert model.config.provider == "openai"
+    assert model.assistant_metadata.title == "t"

--- a/tests/test_assistant_repository.py
+++ b/tests/test_assistant_repository.py
@@ -1,0 +1,39 @@
+import uuid
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.api.assistant.repository import AssistantRepository
+from backend.api.assistant.models import Assistant, AssistantConfig
+
+@pytest.mark.asyncio
+async def test_assistant_repository_crud(session: AsyncSession):
+    # arrange
+    repo = AssistantRepository(session)
+    assistant_in = Assistant(
+        name="assist",
+        account_short_code="acct",
+        config=AssistantConfig(provider="openai", type="rag", model="gpt-4o"),
+        system_prompts={"system": "hi"},
+    )
+
+    # act
+    created = await repo.create_assistant(assistant_in)
+    fetched = await repo.get_assistant_by_id(str(created.id))
+    assistant_update = Assistant(
+        id=created.id,
+        name="assist2",
+        account_short_code="acct",
+        config=AssistantConfig(provider="openai", type="rag", model="gpt-4o"),
+        system_prompts={"system": "hi"},
+    )
+    updated = await repo.update_assistant(assistant_update)
+    listed = await repo.list_assistants("acct")
+    deact = await repo.deactivate_assistant(str(created.id))
+    react = await repo.reactivate_assistant(str(created.id))
+    deleted = await repo.delete_assistant(str(created.id))
+
+    # assert
+    assert fetched.name == "assist"
+    assert updated.name == "assist2"
+    assert len(listed.assistants) >= 1
+    assert deact and react and deleted

--- a/tests/test_assistant_service.py
+++ b/tests/test_assistant_service.py
@@ -1,0 +1,37 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from backend.api.assistant.repository import AssistantRepository
+from backend.api.assistant.services import AssistantService
+from backend.api.assistant.models import Assistant, AssistantConfig
+
+@pytest.mark.asyncio
+async def test_assistant_service_crud(session: AsyncSession):
+    # arrange
+    repo = AssistantRepository(session)
+    service = AssistantService(repo)
+    assistant_in = Assistant(
+        name="svcassist",
+        account_short_code="svc",
+        config=AssistantConfig(provider="openai", type="rag", model="gpt-4o"),
+        system_prompts={"system": "hi"},
+    )
+
+    # act
+    created = await service.create_assistant(assistant_in)
+    fetched = await service.get_assistant(created.id)
+    update = Assistant(
+        id=created.id,
+        name="svcassist2",
+        account_short_code="svc",
+        config=AssistantConfig(provider="openai", type="rag", model="gpt-4o"),
+        system_prompts={"system": "hi"},
+    )
+    updated = await service.update_assistant(update)
+    await service.deactivate_assistant(created.id)
+    await service.reactivate_assistant(created.id)
+    deleted = await service.delete_assistant(created.id)
+
+    # assert
+    assert fetched.name == "svcassist"
+    assert updated.name == "svcassist2"
+    assert deleted

--- a/tests/test_kbase_models.py
+++ b/tests/test_kbase_models.py
@@ -1,0 +1,27 @@
+import uuid
+from backend.api.kbase.kbase_schema import KnowledgeBaseORM
+from backend.api.kbase.models import KnowledgeBase
+
+
+def test_kbase_model_validation():
+    # arrange
+    orm = KnowledgeBaseORM(
+        id=uuid.uuid4(),
+        name="kb",
+        description="d",
+        account_short_code="a",
+    )
+
+    # act
+    model = KnowledgeBase.model_validate(
+        {
+            "id": orm.id,
+            "name": orm.name,
+            "description": orm.description,
+            "account_short_code": orm.account_short_code,
+        }
+    )
+
+    # assert
+    assert model.id == orm.id
+    assert model.name == "kb"

--- a/tests/test_kbase_repository.py
+++ b/tests/test_kbase_repository.py
@@ -1,0 +1,24 @@
+import uuid
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.api.kbase.repository import KbaseRepository
+from backend.api.kbase.models import KnowledgeBase
+
+@pytest.mark.asyncio
+async def test_kbase_repository_crud(session: AsyncSession):
+    # arrange
+    repo = KbaseRepository(session)
+    kbase_in = KnowledgeBase(name="kb1", description="desc", account_short_code="acct")
+
+    # act
+    created = await repo.create_kbase(kbase_in)
+    fetched = await repo.get_kbase_by_id(created.id)
+    kbase_update = KnowledgeBase(id=created.id, name="kb1-up", description="desc", account_short_code="acct")
+    updated = await repo.update_kbase(kbase_update)
+    delete_ok = await repo.delete_kbase(created.id)
+
+    # assert
+    assert fetched.name == "kb1"
+    assert updated.name == "kb1-up"
+    assert delete_ok

--- a/tests/test_kbase_service.py
+++ b/tests/test_kbase_service.py
@@ -1,0 +1,24 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from backend.api.kbase.repository import KbaseRepository
+from backend.api.kbase.services import KbaseService
+from backend.api.kbase.models import KnowledgeBase
+
+@pytest.mark.asyncio
+async def test_kbase_service_crud(session: AsyncSession):
+    # arrange
+    repo = KbaseRepository(session)
+    service = KbaseService(repo)
+    kbase_in = KnowledgeBase(name="svc_kb", description="desc", account_short_code="svc")
+
+    # act
+    created = await service.create_kbase(kbase_in)
+    fetched = await service.get_kbase(created.id)
+    update = KnowledgeBase(id=created.id, name="svc_kb2", description="desc", account_short_code="svc")
+    updated = await service.update_kbase(update)
+    delete_ok = await service.delete_kbase(created.id)
+
+    # assert
+    assert fetched.name == "svc_kb"
+    assert updated.name == "svc_kb2"
+    assert delete_ok

--- a/tests/test_session_repository.py
+++ b/tests/test_session_repository.py
@@ -1,0 +1,29 @@
+import uuid
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.api.session.repository import SessionRepository
+from backend.api.session.models import UserSession
+
+@pytest.mark.asyncio
+async def test_session_repository_crud(session: AsyncSession):
+    # arrange
+    repo = SessionRepository(session)
+    user_session = UserSession(
+        user_id=uuid.uuid4(),
+        account_id=uuid.uuid4(),
+        assistant_id=uuid.uuid4(),
+        title="first",
+    )
+
+    # act
+    created = await repo.set_user_session(user_session)
+    fetched = await repo.get_user_session(created.id)
+    await repo.update_session_title(created.id, "updated")
+    updated = await repo.get_user_session(created.id)
+    deleted = await repo.delete_user_session(created.id)
+
+    # assert
+    assert fetched.title == "first"
+    assert updated.title == "updated"
+    assert deleted

--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -1,0 +1,39 @@
+import uuid
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.api.session.services import SessionService
+from backend.api.session.repository import SessionRepository
+from backend.api.assistant.repository import AssistantRepository
+from backend.api.assistant.models import Assistant, AssistantConfig
+from backend.util.auth_utils import TokenData
+
+@pytest.mark.asyncio
+async def test_session_service_crud(session: AsyncSession):
+    # arrange
+    service = SessionService(session)
+    # create assistant for session
+    assistant_repo = AssistantRepository(session)
+    assistant = await assistant_repo.create_assistant(
+        Assistant(
+            name="s",
+            account_short_code="svc",
+            config=AssistantConfig(provider="openai", type="rag", model="gpt-4o"),
+            system_prompts={"system": "hi"},
+        )
+    )
+    token = TokenData(email=None, account_id=str(uuid.uuid4()), account_short_code="svc", user_id=str(uuid.uuid4()))
+
+    # act
+    sess_obj = await service.create_session_object(token, assistant.id)
+    stored = await service.store_chat_session(sess_obj)
+    fetched = await service.get_session(stored.id)
+    await service.update_session_title(stored.id, "title")
+    updated = await service.get_session(stored.id)
+    deleted = await service.delete_session(stored.id)
+    await assistant_repo.delete_assistant(str(assistant.id))
+
+    # assert
+    assert fetched.id == stored.id
+    assert updated.title == "title"
+    assert deleted


### PR DESCRIPTION
## Summary
- add extensive unit tests for repo and service layers
- document how to run tests in README
- fix async fixtures and adjust model tests

## Testing
- `make test` *(fails: docker not installed)*
- `uv run pytest -q` *(fails: Failed to download python build)*